### PR TITLE
Move to forked bootstrap v3.0.2 to fix #96.

### DIFF
--- a/src/angular/app/index.html
+++ b/src/angular/app/index.html
@@ -1,4 +1,3 @@
-<doctype html>
 <html ng-app="librecmsApp" class="no-js" lang="en">
   <head>
     <meta charset="utf-8">
@@ -76,5 +75,5 @@
     <script src="scripts/controllers/AuthWidget.js"></script>
     <script src="scripts/controllers/currentgrades.js"></script>
     <!-- endbuild -->
-</body>
+  </body>
 </html>

--- a/src/angular/app/views/calendar.html
+++ b/src/angular/app/views/calendar.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="containter col-md-12 col-lg-9" align="center">
+  <div class="col-md-12 col-lg-9" align="center">
     <div class="btn-group">
       <button class="btn btn-success btn-sm col-lg-2 col-sm-2 col-xs-4" ng-click="changeView('agendaDay', myCalendar)">Day</button>
       <button class="btn btn-success btn-sm col-lg-2 col-sm-2 col-xs-4" ng-click="changeView('agendaWeek', myCalendar)">Week</button>
@@ -10,5 +10,5 @@
     </div>
     <div class="calendar" ng-model="eventSources" calendar="myCalendar" config="uiConfig.calendar" ui-calendar="uiConfig.calendar"></div>
   </div>
-  <div class="containter col-md-12 col-lg-3" ui-view></div>
+  <div class="col-md-12 col-lg-3" ui-view></div>
 </div>

--- a/src/angular/app/views/course.assignment.html
+++ b/src/angular/app/views/course.assignment.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
   <div id="assignment-header" class="row">
     <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
       <h3>{{ assignment.name }}</h3>

--- a/src/angular/app/views/course.grades.html
+++ b/src/angular/app/views/course.grades.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
   <div class="row">
     <div class="col-lg-6">
       <h6>Course Grade:</h6>

--- a/src/angular/app/views/course.home.html
+++ b/src/angular/app/views/course.home.html
@@ -1,8 +1,4 @@
 <div>
-	<div class="col-lg-12">
-		<br/>
-		<button ng-click="setNewUser()">Call setNewUser</button>
-	</div>
 	<div id="course-left-container" class="col-xs-12 col-md-7">
 		<div ui-view="upcoming" id="upcoming-events" class="col-xs-12"></div>
 	</div>

--- a/src/angular/app/views/course.item.list.html
+++ b/src/angular/app/views/course.item.list.html
@@ -1,5 +1,5 @@
 <!-- Student View -->
-<div class="container" auth="student">
+<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12" auth="student">
   <div class="row">
     <div class="col-lg-5">
       Sort By: 
@@ -24,7 +24,7 @@
 </div>
 
 <!-- Instructor View -->
-<div class="container" auth="instructor" >
+<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12" auth="instructor" >
   <div class="row">
     <div class="col-lg-5">
       Sort By: 

--- a/src/angular/app/views/main.html
+++ b/src/angular/app/views/main.html
@@ -1,8 +1,8 @@
 <!-- apply palette to parent of container to avoid colors scheme being missed -->
 <div class="palette palette-clouds">
-  <div id="main" class="row palette-peter-river">
+  <div id="main" class="row palette-peter-river container">
 
-    <div id="left-container" class="col-lg-2 col-md-3 col-sm-3 col-xs-12 palette palette-peter-river">
+    <div id="left-container" class="col-lg-2 col-md-2 col-sm-2 col-xs-12 palette palette-peter-river">
       <div id="left-navbar-container"> 
         <div class="row navbar-section">
           <div id="left-navbar-user-container" class="col-lg-12 col-md-12 col-sm-12">
@@ -46,7 +46,7 @@
 
     </div>
 
-    <div id="center-container" class="col-lg-10 col-md-9 col-sm-9 palette-clouds">
+    <div id="center-container" class="col-lg-10 col-md-10 col-sm-10 col-xs-12 palette-clouds">
       <div id="top-widget" class="row">
         <nav id="top-navbar" class="navbar navbar-default" role="navigation">
           <!-- Brand and toggle get grouped for better mobile display -->

--- a/src/angular/app/views/user.home.html
+++ b/src/angular/app/views/user.home.html
@@ -1,8 +1,4 @@
 <div>
-	<div class="col-lg-12">
-		<br/>
-		<button ng-click="setNewUser()">Call setNewUser</button>
-	</div>
 	<div id="home-left-container" class="col-xs-12 col-md-7">
 		<div ui-view="upcoming" class="col-xs-12 col-sm-6 col-md-12"></div>
 		<div class="row">

--- a/src/angular/app/views/widgets/currentgrades.html
+++ b/src/angular/app/views/widgets/currentgrades.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="">
 	<div class="currentgrades">
 		<div class="row">
 			<div class="col-xs-12">

--- a/src/angular/app/views/widgets/eventbar.html
+++ b/src/angular/app/views/widgets/eventbar.html
@@ -1,17 +1,21 @@
-<div ng-controller="EventbarCtrl">
-    <h4 class="upcoming-events-title">Upcoming Events</h4>
-    <div ng-show="!events.length" class="alert alert-danger">No Upcoming Events</div>
-    <div ng-show="events.length" class="upcoming-events-container">
-    	<h5 class="upcoming-events-month">{{ events[0].start | date:"MMMM" }}</h5>
-    	<div ng-repeat="e in events | orderBy:predicate | limitTo:quantity" class="row upcoming-event">
-            <div class="alert alert-info">
-                <input type="checkbox" ng-model="strike">
-                	<div class="col-xs-3 col-sm-3 col-md-2">
-                		<h6 class="upcoming-event-day">{{e.start | date:"dd" }}</h6>
-                		<h6 class="upcoming-event-month">{{e.start | date:"EEE" }}<h6>
-                	</div>
-                <div ng-class="{strike:strike}" class="col-xs-9 col-sm-9 col-md-10">{{e.title}}</div>
-            </div>
+<div>
+  <h4 class="upcoming-events-title">Upcoming Events</h4>
+  <div ng-show="!events.length" class="alert alert-danger">
+    No Upcoming Events
+  </div>
+  <div ng-show="events.length" class="upcoming-events-container">
+    <h5 class="upcoming-events-month">{{ events[0].start | date:"MMMM" }}</h5>
+    <div ng-repeat="e in events | orderBy:predicate | limitTo:quantity" class="row upcoming-event">
+      <div class="alert alert-info">
+        <input type="checkbox" ng-model="strike"></input>
+        <div class="col-xs-3 col-sm-3 col-md-2">
+          <h6 class="upcoming-event-day">{{e.start | date:"dd" }}</h6>
+          <h6 class="upcoming-event-month">{{e.start | date:"EEE" }}<h6>
         </div>
+        <div ng-class="{strike:strike}" class="col-xs-9 col-sm-9 col-md-10">
+          {{e.title}}
+        </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/src/angular/app/views/widgets/timeline.html
+++ b/src/angular/app/views/widgets/timeline.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="">
   <div class="new-post">
     <div class="new-post-container row" auth="instructor">
       <div class="col-xs-8" >

--- a/src/angular/bower.json
+++ b/src/angular/bower.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "angular": "1.2.0-rc.3",
     "angular-ui-router": "~0.2.0",
-    "bootstrap": "3.0.0",
+    "bootstrap": "https://github.com/librecms/bootstrap.git#e922ae8c764dcc4e768e6009280c259c3c004ccf",
     "es5-shim": "~2.0.8",
     "flatui": "https://github.com/designmodo/Flat-UI.git#32491d5da1c0af5a047dfe6c8d4c38117563e9b5",
     "jquery": "~2.0.3",


### PR DESCRIPTION
This changes the width of bootstrap's 'container' class to accomodate
for the scrollbar width without sacrificing much screen real-estate.
See
https://github.com/librecms/bootstrap/commit/e922ae8c764dcc4e768e6009280c259c3c004ccf
